### PR TITLE
Set ro.product.manufacturer=Google

### DIFF
--- a/vendor.prop
+++ b/vendor.prop
@@ -42,6 +42,8 @@ vendor.sec.rild.libpath2=/vendor/lib64/libsec-ril-dsds.so
 debug.slsi_platform=1
 
 # SoC
+ro.product.vendor.manufacturer=Google
+ro.product.manufacturer=Google
 ro.soc.manufacturer=Samsung
 ro.soc.model=Exynos 8890
 


### PR DESCRIPTION
this will fix Quick share on samsung and maybe in other brands too